### PR TITLE
Add modal details and improved search

### DIFF
--- a/README
+++ b/README
@@ -19,6 +19,8 @@ Simple Pin Viewer Webpage for creating and viewing geolocated news. The main das
 - 📍 Display latest accident news as map pins
 - 🔎 Clickable markers with title and “Read more” links
 - 📋 Sidebar list view of all pins
+- 🗒️ Search now matches pin descriptions
+- 🛠️ Detailed modal with coordinates and description
 - 🌐 Responsive layout with Bootstrap
 - 🏳️ Language switcher (EN/SQ/SR)
 


### PR DESCRIPTION
## Summary
- support search in pin descriptions
- show pin details in a modal when markers or list entries are clicked
- avoid errors if search inputs are missing
- document new features

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_684fd1e90e4c8324ad166bb6b67a0ba7