### PR TITLE
Add news details page with new read more flow

### DIFF
--- a/README
+++ b/README
@@ -17,7 +17,7 @@ Simple Pin Viewer Webpage for creating and viewing geolocated news. The main das
 ## Features
 
 - 📍 Display latest accident news as map pins
-- 🔎 Clickable markers with title and “Read more” links
+ - 🔎 Clickable markers with title and “Read more” links to a detail page
 - 📋 Sidebar list view of all pins
 - 🗒️ Search now matches pin descriptions
 - 🛠️ Detailed modal with coordinates and description

--- a/app.js
+++ b/app.js
@@ -169,9 +169,9 @@ function addMarkers(pins) {
     const marker = L.marker([pin.lat, pin.lng])
       .addTo(map)
       .bindPopup(
-        `<b>${getLocalizedTitle(pin)}</b><br><a href="${
-          pin.articleUrl
-        }" target="_blank">Read more</a>`
+        `<b>${getLocalizedTitle(pin)}</b><br><a href="news.html?id=${
+          pin.id
+        }">Read more</a>`
       )
       .on("click", () => showPinDetails(pin));
     markers.push(marker);
@@ -215,6 +215,8 @@ function showPinDetails(pin) {
   document.getElementById("pinCoords").textContent = `${pin.lat}, ${pin.lng}`;
   document.getElementById("pinCategory").textContent = pin.category || "N/A";
   document.getElementById("pinModalLabel").textContent = getLocalizedTitle(pin);
+  const readMore = document.getElementById("modalReadMore");
+  if (readMore) readMore.href = `news.html?id=${pin.id}`;
   const modal = new bootstrap.Modal(document.getElementById("pinModal"));
   modal.show();
 }

--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
                 <strong>Category:</strong> <span id="pinCategory"></span>
               </li>
             </ul>
+            <a id="modalReadMore" href="#" class="btn btn-link mt-2" target="_blank">Read more</a>
           </div>
           <div class="modal-footer">
             <button

--- a/news.html
+++ b/news.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>News Details</title>
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+      rel="stylesheet"
+      crossorigin="anonymous"
+    />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body class="d-flex flex-column min-vh-100">
+    <nav class="navbar navbar-dark bg-dark px-3">
+      <a class="navbar-brand d-flex align-items-center" href="index.html">
+        <img src="./QKSS-logo.jpg.png" alt="QKSS-logo" height="40" />
+      </a>
+      <div class="ms-auto d-flex align-items-center gap-2">
+        <div class="nav-item dropdown">
+          <a
+            class="nav-link dropdown-toggle text-light"
+            href="#"
+            id="langDropdown"
+            role="button"
+            data-bs-toggle="dropdown"
+            aria-expanded="false"
+          >
+            <i class="bi bi-translate"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="langDropdown">
+            <li><button class="dropdown-item lang-option" data-lang="en">English</button></li>
+            <li><button class="dropdown-item lang-option" data-lang="sq">Shqip</button></li>
+            <li><button class="dropdown-item lang-option" data-lang="sr">Srpski</button></li>
+          </ul>
+        </div>
+      </div>
+    </nav>
+
+    <main class="flex-grow-1 container py-4" id="content">
+      <h2 id="newsTitle" class="mb-3"></h2>
+      <p id="newsDescription"></p>
+      <p>
+        <strong>Coordinates:</strong> <span id="newsCoords"></span><br />
+        <strong>Category:</strong> <span id="newsCategory"></span>
+      </p>
+      <p>
+        <a id="externalLink" href="#" target="_blank" class="btn btn-primary">Open Original Article</a>
+        <a href="index.html" class="btn btn-secondary ms-2">&larr; Back to Map</a>
+      </p>
+    </main>
+
+    <footer class="bg-dark text-light text-center py-2 mt-auto">
+      <small>© 2025 QKSS Map Viewer. Data sourced from our API.</small>
+    </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" crossorigin="anonymous"></script>
+    <script src="config.js"></script>
+    <script>
+      function getLang() {
+        return localStorage.getItem("lang") || "en";
+      }
+      function setLang(lang) {
+        localStorage.setItem("lang", lang);
+        updateLangDropdownDisplay();
+        loadNews();
+      }
+      const LANG_LABELS = { en: "English", sq: "Shqip", sr: "Srpski" };
+      const UI_STRINGS = {
+        en: {
+          externalLink: "Open Original Article",
+          back: "\u2190 Back to Map",
+          coordsLabel: "Coordinates:",
+          categoryLabel: "Category:",
+        },
+        sq: {
+          externalLink: "Hape Artikullin",
+          back: "\u2190 Kthehu te Harta",
+          coordsLabel: "Koordinatat:",
+          categoryLabel: "Kategoria:",
+        },
+        sr: {
+          externalLink: "Otvorite Članak",
+          back: "\u2190 Nazad na mapu",
+          coordsLabel: "Koordinate:",
+          categoryLabel: "Kategorija:",
+        },
+      };
+      function updateLangDropdownDisplay() {
+        const current = getLang();
+        const toggle = document.getElementById("langDropdown");
+        toggle.innerHTML = `<i class="bi bi-translate"></i> ${LANG_LABELS[current]}`;
+      }
+      document.querySelectorAll(".lang-option").forEach((btn) => {
+        btn.addEventListener("click", () => setLang(btn.dataset.lang));
+      });
+      updateLangDropdownDisplay();
+
+      async function loadNews() {
+        const params = new URLSearchParams(window.location.search);
+        const id = params.get("id");
+        if (!id) return;
+        try {
+          const res = await fetch(`${API_BASE_URL}/pins/${id}`);
+          if (!res.ok) throw new Error("Failed to load news");
+          const pin = await res.json();
+          const lang = getLang();
+          const title = (pin.title && pin.title[lang]) || pin.title?.en || pin.title || "";
+          const desc = (pin.description && pin.description[lang]) || pin.description?.en || pin.description || "";
+          document.getElementById("newsTitle").textContent = title;
+          document.getElementById("newsDescription").textContent = desc;
+          document.getElementById("newsCoords").textContent = `${pin.lat}, ${pin.lng}`;
+          document.getElementById("newsCategory").textContent = pin.category || "N/A";
+          const u = UI_STRINGS[getLang()];
+          document.getElementById("externalLink").textContent = u.externalLink;
+          document.getElementById("externalLink").href = pin.articleUrl || "#";
+          document.querySelector("a.btn-secondary").textContent = u.back;
+          document.querySelector("#newsCoords").previousSibling.textContent = `${u.coordsLabel} `;
+          document.querySelector("#newsCategory").previousSibling.textContent = `${u.categoryLabel} `;
+        } catch (err) {
+          document.getElementById("content").innerHTML = `<div class="alert alert-danger">Unable to load news.</div>`;
+        }
+      }
+      window.addEventListener("DOMContentLoaded", loadNews);
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated `news.html` page to display article details
- hook map popups and modal "Read more" link to this page
- include link in modal body
- update README feature description

## Testing
- `npm test` *(fails: ENOENT: no package.json)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_684fd49bbe808324903150d9905b1ea2