### PR TITLE
Add single pin retrieval endpoint

### DIFF
--- a/service/map/src/main/java/com/qkss/map/controller/PinController.java
+++ b/service/map/src/main/java/com/qkss/map/controller/PinController.java
@@ -25,6 +25,12 @@ public class PinController {
         return service.listPins();
     }
 
+    // 1b) Public endpoint: get pin by ID
+    @GetMapping("/{id}")
+    public ResponseEntity<PinDTO> getPin(@PathVariable String id) {
+        return ResponseEntity.ok(service.getPin(id));
+    }
+
     // 2) Login endpoint: accepts {"password":"admin123"}, returns raw JWT
     @PostMapping("/admin/login")
     public ResponseEntity<String> login(@RequestBody Map<String, String> body) {

--- a/service/map/src/main/java/com/qkss/map/service/PinService.java
+++ b/service/map/src/main/java/com/qkss/map/service/PinService.java
@@ -19,6 +19,11 @@ public interface PinService {
     PinDTO createPin(CreatePinDTO createPinDTO);
 
     /**
+     * Retrieve a single pin by id or throw if not found.
+     */
+    PinDTO getPin(String id);
+
+    /**
      * Delete the pin with the given id, or throw if not found.
      */
     void deletePin(String id);

--- a/service/map/src/main/java/com/qkss/map/service/PinServiceImpl.java
+++ b/service/map/src/main/java/com/qkss/map/service/PinServiceImpl.java
@@ -53,6 +53,19 @@ public class PinServiceImpl implements PinService {
     }
 
     @Override
+    public PinDTO getPin(String id) {
+        Pin pin = pinRepository.findById(id)
+                .orElseThrow(() -> new PinNotFoundException("Pin not found with id: " + id));
+        return new PinDTO(
+                pin.getId(),
+                pin.getTitle(),
+                pin.getLat(),
+                pin.getLng(),
+                pin.getArticleUrl()
+        );
+    }
+
+    @Override
     public void deletePin(String id) {
         Pin pin = pinRepository.findById(id)
                 .orElseThrow(() -> new PinNotFoundException("Pin not found with id: " + id));

--- a/service/map/src/test/java/com/qkss/map/service/PinServiceImplTest.java
+++ b/service/map/src/test/java/com/qkss/map/service/PinServiceImplTest.java
@@ -1,0 +1,57 @@
+package com.qkss.map.service;
+
+import com.qkss.map.dto.CreatePinDTO;
+import com.qkss.map.dto.PinDTO;
+import com.qkss.map.exception.PinNotFoundException;
+import com.qkss.map.model.Pin;
+import com.qkss.map.repository.PinRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class PinServiceImplTest {
+
+    @Mock
+    private PinRepository repo;
+
+    private PinServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new PinServiceImpl(repo);
+    }
+
+    @Test
+    void getPin_returnsDto_whenFound() {
+        Pin pin = Pin.builder()
+                .id("1")
+                .title(Map.of("en", "t"))
+                .lat(1.0)
+                .lng(2.0)
+                .articleUrl("u")
+                .build();
+        when(repo.findById("1")).thenReturn(Optional.of(pin));
+
+        PinDTO dto = service.getPin("1");
+
+        assertEquals("1", dto.getId());
+        assertEquals(1.0, dto.getLat());
+        assertEquals(2.0, dto.getLng());
+        assertEquals("u", dto.getArticleUrl());
+        verify(repo).findById("1");
+    }
+
+    @Test
+    void getPin_throws_whenMissing() {
+        when(repo.findById("x")).thenReturn(Optional.empty());
+        assertThrows(PinNotFoundException.class, () -> service.getPin("x"));
+    }
+}


### PR DESCRIPTION
## Summary
- add `getPin` method to service layer
- expose `GET /api/pins/{id}` endpoint
- implement service logic
- add unit tests for `PinServiceImpl`

## Testing
- `./mvnw test -q` *(fails: Failed to fetch apache-maven because network access is blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684fd5cf8be8832497250573857ff497