### PR TITLE
Fix API base URL scheme

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,1 +1,4 @@
-const API_BASE_URL = "127.0.0.1:8002/api";
+// Base URL for the REST API used by the frontend.
+// Include the scheme to avoid relative URL issues in the browser.
+// Change this value when pointing the frontend to a different backend.
+const API_BASE_URL = "http://127.0.0.1:8002/api";


### PR DESCRIPTION
## Summary
- fix API base URL in `config.js` so the frontend uses an absolute URL

## Testing
- `chmod +x mvnw && ./mvnw test -q` *(fails: network blocked)*

------
https://chatgpt.com/codex/tasks/task_e_684ff7429ffc832496f892efcf2011ed