### PR TITLE
Fix missing fields in backend pin responses

### DIFF
--- a/service/map/src/main/java/com/qkss/map/dto/PinDTO.java
+++ b/service/map/src/main/java/com/qkss/map/dto/PinDTO.java
@@ -31,8 +31,12 @@ public class PinDTO {
 
     private Map<String, String> title;
 
+    private Map<String, String> description;
+
     private double lat;
     private double lng;
+
+    private String city;
 
     private String articleUrl;
 }

--- a/service/map/src/main/java/com/qkss/map/service/PinServiceImpl.java
+++ b/service/map/src/main/java/com/qkss/map/service/PinServiceImpl.java
@@ -23,8 +23,10 @@ public class PinServiceImpl implements PinService {
                 .map(pin -> new PinDTO(
                         pin.getId(),
                         pin.getTitle(),
+                        pin.getDescription(),
                         pin.getLat(),
                         pin.getLng(),
+                        pin.getCity(),
                         pin.getArticleUrl()
                 ))
                 .collect(Collectors.toList());
@@ -46,8 +48,10 @@ public class PinServiceImpl implements PinService {
         return new PinDTO(
                 saved.getId(),
                 saved.getTitle(),
+                saved.getDescription(),
                 saved.getLat(),
                 saved.getLng(),
+                saved.getCity(),
                 saved.getArticleUrl()
         );
     }
@@ -59,8 +63,10 @@ public class PinServiceImpl implements PinService {
         return new PinDTO(
                 pin.getId(),
                 pin.getTitle(),
+                pin.getDescription(),
                 pin.getLat(),
                 pin.getLng(),
+                pin.getCity(),
                 pin.getArticleUrl()
         );
     }

--- a/service/map/src/test/java/com/qkss/map/service/PinServiceImplTest.java
+++ b/service/map/src/test/java/com/qkss/map/service/PinServiceImplTest.java
@@ -34,8 +34,10 @@ class PinServiceImplTest {
         Pin pin = Pin.builder()
                 .id("1")
                 .title(Map.of("en", "t"))
+                .description(Map.of("en", "d"))
                 .lat(1.0)
                 .lng(2.0)
+                .city("c")
                 .articleUrl("u")
                 .build();
         when(repo.findById("1")).thenReturn(Optional.of(pin));
@@ -46,6 +48,8 @@ class PinServiceImplTest {
         assertEquals(1.0, dto.getLat());
         assertEquals(2.0, dto.getLng());
         assertEquals("u", dto.getArticleUrl());
+        assertEquals("c", dto.getCity());
+        assertEquals(Map.of("en", "d"), dto.getDescription());
         verify(repo).findById("1");
     }
 


### PR DESCRIPTION
## Summary
- return description and city in `PinDTO`
- map new fields in `PinServiceImpl`
- update service tests for new `PinDTO`

## Testing
- `sh ./service/map/mvnw -q test` *(fails: could not fetch maven)*

------
https://chatgpt.com/codex/tasks/task_e_6850029677dc83249acc4f3782c19ebb