### PR TITLE
Restructure frontend paths for /home and /admin

### DIFF
--- a/README
+++ b/README
@@ -37,6 +37,9 @@ Simple Pin Viewer Webpage for creating and viewing geolocated news. The main das
    git clone https://github.com/festimii/QKSS.git
    cd QKSS
    ```
+   Open `home/index.html` in your browser for the main site.
+   The admin interface is served from the `admin/` directory.
+
 2. **Build Backend**
    ./mvnw clean package
    java -jar target/map-0.0.1-SNAPSHOT.jar

--- a/admin/newpin/index.html
+++ b/admin/newpin/index.html
@@ -44,7 +44,7 @@
     <script>
       function logout() {
         sessionStorage.removeItem("jwt_token");
-        window.location.href = "/auth/";
+        window.location.href = "../auth/";
       }
     </script>
     <div class="container">

--- a/home/index.html
+++ b/home/index.html
@@ -24,14 +24,14 @@
       href="https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/leaflet.fullscreen.css"
     />
 
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="../style.css" />
   </head>
   <body class="d-flex flex-column vh-100">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="index.html">
           <img
-            src="./QKSS-logo.jpg.png"
+            src="../QKSS-logo.jpg.png"
             alt="QKSS-logo"
             height="40"
             class="me-2"
@@ -156,7 +156,7 @@
     ></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <script src="https://api.mapbox.com/mapbox.js/plugins/leaflet-fullscreen/v1.0.1/Leaflet.fullscreen.min.js"></script>
-    <script src="config.js"></script>
-    <script src="app.js"></script>
+    <script src="../config.js"></script>
+    <script src="../app.js"></script>
   </body>
 </html>

--- a/home/news.html
+++ b/home/news.html
@@ -13,14 +13,14 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="../style.css" />
   </head>
   <body class="d-flex flex-column min-vh-100">
     <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="index.html">
           <img
-            src="./QKSS-logo.jpg.png"
+            src="../QKSS-logo.jpg.png"
             alt="QKSS-logo"
             height="40"
             class="me-2"
@@ -113,7 +113,7 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       crossorigin="anonymous"
     ></script>
-    <script src="config.js"></script>
+    <script src="../config.js"></script>
     <script>
       function getLang() {
         return localStorage.getItem("lang") || "en";


### PR DESCRIPTION
## Summary
- move public pages into `home/`
- update references to assets for new folder structure
- fix logout link in admin new pin page
- document new paths in the README

## Testing
- `sh mvnw -q test` *(fails: cannot open mvnw/.mvn/wrapper/maven-wrapper.properties)*

------
https://chatgpt.com/codex/tasks/task_e_68500d9923708324a6db065aba167aad