### PR TITLE
Fix category filter query

### DIFF
--- a/app.js
+++ b/app.js
@@ -164,7 +164,7 @@ function getLocalizedDescription(pin) {
 async function fetchPins(filters = {}) {
   const params = new URLSearchParams();
   if (filters.categories && filters.categories.length) {
-    params.set("categories", filters.categories.join(","));
+    filters.categories.forEach((c) => params.append("categories", c));
   }
   if (filters.start) {
     params.set("start", filters.start.toISOString());


### PR DESCRIPTION
## Summary
- fix query parameter generation for multiple categories

## Testing
- `./mvnw test -q` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851a3a46fa883249d1257bac6f77efd