### PR TITLE
Move filtering logic to backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -227,18 +227,6 @@ function filterPins() {
     const title = getLocalizedTitle(pin).toLowerCase();
     const desc = getLocalizedDescription(pin).toLowerCase();
     if (!title.includes(q) && !desc.includes(q)) return false;
-
-    if (startFilter || endFilter) {
-      if (!pin.timestamp) return false;
-      const ts = new Date(pin.timestamp);
-      if (startFilter && ts < startFilter) return false;
-      if (endFilter && ts > endFilter) return false;
-    }
-
-    if (activeCategories.size > 0) {
-      const cat = pin.subcategory || pin.category;
-      if (!activeCategories.has(cat)) return false;
-    }
     return true;
   });
   populateList(filtered);

--- a/service/map/src/test/java/com/qkss/map/service/PinServiceImplTest.java
+++ b/service/map/src/test/java/com/qkss/map/service/PinServiceImplTest.java
@@ -5,6 +5,7 @@ import com.qkss.map.dto.PinDTO;
 import com.qkss.map.exception.PinNotFoundException;
 import com.qkss.map.model.Pin;
 import com.qkss.map.repository.PinRepository;
+import org.springframework.data.mongodb.core.MongoTemplate;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -21,13 +22,15 @@ class PinServiceImplTest {
 
     @Mock
     private PinRepository repo;
+    @Mock
+    private MongoTemplate mongoTemplate;
 
     private PinServiceImpl service;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        service = new PinServiceImpl(repo);
+        service = new PinServiceImpl(repo, mongoTemplate);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- query MongoDB for filters in `PinServiceImpl`
- inject `MongoTemplate` into `PinServiceImpl` and update tests
- narrow `filterPins` logic in `app.js` to only handle search

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851a744c40c8324a9ff032b077317eb