### PR TITLE
Add translations for new interface elements

### DIFF
--- a/app.js
+++ b/app.js
@@ -31,6 +31,19 @@ const UI_STRINGS = {
     labelUrl: "Article URL",
     btnSubmit: "Submit",
     btnBack: "⬅ Back",
+    filtersBtn: "Filters",
+    filtersTitle: "Filters",
+    categoriesHeading: "Categories",
+    riskSummary: "Risk & Tensions 🔴",
+    positiveSummary: "Positive Developments 🟢",
+    institutionalSummary: "Institutional Responses & Monitoring ⚖️",
+    dateRangeLabel: "Date range",
+    dateRangeTo: "to",
+    applyFilters: "Apply",
+    cancel: "Cancel",
+    readMore: "Read more",
+    copyLink: "Copy Link",
+    copied: "Copied!",
   },
   sq: {
     locations: "Vendndodhjet",
@@ -59,6 +72,19 @@ const UI_STRINGS = {
     labelUrl: "URL Artikulli",
     btnSubmit: "Dërgo",
     btnBack: "⬅ Kthehu",
+    filtersBtn: "Filtrat",
+    filtersTitle: "Filtrat",
+    categoriesHeading: "Kategoritë",
+    riskSummary: "Rreziqet dhe Tensionet 🔴",
+    positiveSummary: "Zhvillimet Pozitive 🟢",
+    institutionalSummary: "Përgjigjet Institucionale & Monitorimi ⚖️",
+    dateRangeLabel: "Periudha",
+    dateRangeTo: "deri",
+    applyFilters: "Apliko",
+    cancel: "Anulo",
+    readMore: "Lexo më shumë",
+    copyLink: "Kopjo Lidhjen",
+    copied: "U kopjua!",
   },
   sr: {
     locations: "Lokacije",
@@ -87,6 +113,19 @@ const UI_STRINGS = {
     labelUrl: "URL Članka",
     btnSubmit: "Sačuvaj",
     btnBack: "⬅ Nazad",
+    filtersBtn: "Filteri",
+    filtersTitle: "Filteri",
+    categoriesHeading: "Kategorije",
+    riskSummary: "Rizici i Tenzije 🔴",
+    positiveSummary: "Pozitivni Razvoj 🟢",
+    institutionalSummary: "Institucionalni Odgovori & Monitoring ⚖️",
+    dateRangeLabel: "Vremenski period",
+    dateRangeTo: "do",
+    applyFilters: "Primeni",
+    cancel: "Otkaži",
+    readMore: "Pročitaj više",
+    copyLink: "Kopiraj Link",
+    copied: "Kopirano!",
   },
 };
 
@@ -186,9 +225,7 @@ function addMarkers(pins) {
     const marker = L.marker([pin.lat, pin.lng])
       .addTo(map)
       .bindPopup(
-        `<b>${getLocalizedTitle(pin)}</b><br><a href="news/?id=${
-          pin.id
-        }">Read more</a>`
+        `<b>${getLocalizedTitle(pin)}</b><br><a href="news/?id=${pin.id}">${UI_STRINGS[getLang()].readMore}</a>`
       )
       .on("click", () => showPinDetails(pin));
     markers.push(marker);
@@ -249,11 +286,12 @@ function showPinDetails(pin) {
 
 function copyModalLink() {
   const link = document.getElementById("modalReadMore").href;
+  const u = UI_STRINGS[getLang()];
   navigator.clipboard.writeText(link).then(() => {
     const btn = document.activeElement;
     if (btn && btn.tagName === "BUTTON") {
-      btn.textContent = "Copied!";
-      setTimeout(() => (btn.textContent = "Copy Link"), 1500);
+      btn.textContent = u.copied;
+      setTimeout(() => (btn.textContent = u.copyLink), 1500);
     }
   });
 }
@@ -369,11 +407,38 @@ function updateUIStrings() {
     .getElementById("searchInput")
     .setAttribute("placeholder", u.searchPlaceholder);
 
+  const filterBtn = document.getElementById("openFilterModal");
+  if (filterBtn) filterBtn.textContent = u.filtersBtn;
+
   document.getElementById("pinModalTitle").textContent = u.pinDetailsTitle;
   const cityLbl = document.getElementById("cityLabel");
   if (cityLbl) cityLbl.textContent = u.cityLabel;
   const catLbl = document.getElementById("categoryLabel");
   if (catLbl) catLbl.textContent = u.categoryLabel;
+
+  const copyBtn = document.getElementById("copyLinkBtn");
+  if (copyBtn) copyBtn.textContent = u.copyLink;
+  const readMore = document.getElementById("modalReadMore");
+  if (readMore) readMore.textContent = u.readMore;
+
+  const fmTitle = document.getElementById("filterModalTitle");
+  if (fmTitle) fmTitle.textContent = u.filtersTitle;
+  const catHeading = document.getElementById("categoriesHeading");
+  if (catHeading) catHeading.textContent = u.categoriesHeading;
+  const sumRisk = document.getElementById("summaryRisk");
+  if (sumRisk) sumRisk.textContent = u.riskSummary;
+  const sumPos = document.getElementById("summaryPositive");
+  if (sumPos) sumPos.textContent = u.positiveSummary;
+  const sumInst = document.getElementById("summaryInstitutional");
+  if (sumInst) sumInst.textContent = u.institutionalSummary;
+  const dateLbl = document.getElementById("dateRangeLabel");
+  if (dateLbl) dateLbl.textContent = u.dateRangeLabel;
+  const dateTo = document.getElementById("dateRangeTo");
+  if (dateTo) dateTo.textContent = u.dateRangeTo;
+  const applyBtn = document.getElementById("applyFilters");
+  if (applyBtn) applyBtn.textContent = u.applyFilters;
+  const cancelBtn = document.getElementById("cancelFilters");
+  if (cancelBtn) cancelBtn.textContent = u.cancel;
   document
     .querySelector("#pinModal .btn-close")
     .setAttribute("aria-label", u.close);

--- a/index.html
+++ b/index.html
@@ -138,7 +138,7 @@
             </p>
             <div class="mt-3 d-flex gap-2">
               <a id="modalReadMore" href="#" class="btn btn-primary" target="_blank">Read more</a>
-              <button class="btn btn-outline-secondary" onclick="copyModalLink()">Copy Link</button>
+              <button id="copyLinkBtn" class="btn btn-outline-secondary" onclick="copyModalLink()">Copy Link</button>
             </div>
           </div>
           <div class="modal-footer">
@@ -158,14 +158,14 @@
       <div class="modal-dialog">
         <div class="modal-content">
           <div class="modal-header">
-            <h5 class="modal-title">Filters</h5>
-            <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            <h5 class="modal-title" id="filterModalTitle">Filters</h5>
+            <button id="filterModalClose" type="button" class="btn-close" data-bs-dismiss="modal"></button>
           </div>
           <div class="modal-body">
             <div class="mb-3">
-              <h6>Categories</h6>
+              <h6 id="categoriesHeading">Categories</h6>
               <details>
-                <summary>Risk &amp; Tensions 🔴</summary>
+                <summary id="summaryRisk">Risk &amp; Tensions 🔴</summary>
                 <div class="form-check">
                   <input class="form-check-input category-filter" type="checkbox" value="Violent Incidents" id="cat-violent" />
                   <label class="form-check-label" for="cat-violent">Violent Incidents</label>
@@ -180,7 +180,7 @@
                 </div>
               </details>
               <details class="mt-2">
-                <summary>Positive Developments 🟢</summary>
+                <summary id="summaryPositive">Positive Developments 🟢</summary>
                 <div class="form-check">
                   <input class="form-check-input category-filter" type="checkbox" value="Interethnic Cooperation Initiatives" id="cat-coop" />
                   <label class="form-check-label" for="cat-coop">Interethnic Cooperation Initiatives</label>
@@ -195,7 +195,7 @@
                 </div>
               </details>
               <details class="mt-2">
-                <summary>Institutional Responses &amp; Monitoring ⚖️</summary>
+                <summary id="summaryInstitutional">Institutional Responses &amp; Monitoring ⚖️</summary>
                 <div class="form-check">
                   <input class="form-check-input category-filter" type="checkbox" value="Arrests &amp; Legal Actions" id="cat-arrests" />
                   <label class="form-check-label" for="cat-arrests">Arrests &amp; Legal Actions</label>
@@ -211,16 +211,16 @@
               </details>
             </div>
             <div class="mb-3">
-              <label class="form-label" for="startDate">Date range</label>
+              <label class="form-label" id="dateRangeLabel" for="startDate">Date range</label>
               <div class="input-group">
                 <input type="month" id="startDate" class="form-control" min="2025-01" />
-                <span class="input-group-text">to</span>
+                <span class="input-group-text" id="dateRangeTo">to</span>
                 <input type="month" id="endDate" class="form-control" />
               </div>
             </div>
           </div>
           <div class="modal-footer">
-            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+            <button id="cancelFilters" type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
             <button id="applyFilters" type="button" class="btn btn-primary">Apply</button>
           </div>
         </div>

--- a/news/index.html
+++ b/news/index.html
@@ -94,7 +94,7 @@
               class="btn btn-primary"
               >Open Original Article</a
             >
-            <button class="btn btn-outline-secondary" onclick="copyNewsLink()">
+            <button id="copyLinkBtn" class="btn btn-outline-secondary" onclick="copyNewsLink()">
               Copy Link
             </button>
             <a href="/" class="btn btn-secondary ms-auto"
@@ -130,18 +130,24 @@
           back: "\u2190 Back to Map",
           coordsLabel: "Coordinates:",
           categoryLabel: "City:",
+          copyLink: "Copy Link",
+          copied: "Copied!",
         },
         sq: {
           externalLink: "Hape Artikullin",
           back: "\u2190 Kthehu te Harta",
           coordsLabel: "Koordinatat:",
           categoryLabel: "Qyteti:",
+          copyLink: "Kopjo Lidhjen",
+          copied: "U kopjua!",
         },
         sr: {
           externalLink: "Otvorite Članak",
           back: "\u2190 Nazad na mapu",
           coordsLabel: "Koordinate:",
           categoryLabel: "Цити:",
+          copyLink: "Kopiraj Link",
+          copied: "Kopirano!",
         },
       };
       function updateLangDropdownDisplay() {
@@ -183,6 +189,7 @@
           document.getElementById("externalLink").textContent = u.externalLink;
           document.getElementById("externalLink").href = pin.articleUrl || "#";
           document.querySelector("a.btn-secondary").textContent = u.back;
+          document.getElementById("copyLinkBtn").textContent = u.copyLink;
           document.getElementById("coordsLabel").textContent = u.coordsLabel;
           document.getElementById("categoryLabel").textContent =
             u.categoryLabel;
@@ -195,11 +202,12 @@
       window.addEventListener("DOMContentLoaded", loadNews);
 
       function copyNewsLink() {
+        const u = UI_STRINGS[getLang()];
         navigator.clipboard.writeText(window.location.href).then(() => {
           const btn = document.activeElement;
           if (btn && btn.tagName === "BUTTON") {
-            btn.textContent = "Copied!";
-            setTimeout(() => (btn.textContent = "Copy Link"), 1500);
+            btn.textContent = u.copied;
+            setTimeout(() => (btn.textContent = u.copyLink), 1500);
           }
         });
       }


### PR DESCRIPTION
## Summary
- provide translation strings for filter modal, copy-link button and read-more text
- update UI initialization to populate new translated strings
- localize "Copy Link" interactions and filter modal elements

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6851b6bdfbc883249830e2f85339558e