### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/about.html
+++ b/about.html
@@ -10,14 +10,21 @@
       crossorigin="anonymous"
     />
     <link rel="stylesheet" href="style.css" />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
   </head>
   <body class="d-flex flex-column vh-100">
-    <nav class="navbar navbar-expand-lg bg-white">
+    <nav class="navbar navbar-expand-lg bg-body">
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="./">
           <img src="KCSS-logo.png" alt="KCSS logo" height="40" class="me-2" />
           <span>KCSS Map</span>
         </a>
+        <button class="btn btn-outline-dark ms-auto" id="themeToggle">
+          <i class="bi bi-moon"></i>
+        </button>
       </div>
     </nav>
     <main class="flex-grow-1 container my-4">
@@ -50,7 +57,7 @@
         coexistence.
       </p>
     </main>
-    <footer class="bg-dark text-light text-center py-2">
+    <footer class="text-center py-2">
       <small>
         This site is part of a project supported by NED (National Endowment for
         Democracy), titled &#39;Increasing Government Transparency and
@@ -64,5 +71,6 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       crossorigin="anonymous"
     ></script>
+    <script src="theme.js"></script>
   </body>
 </html>

--- a/admin/auth/index.html
+++ b/admin/auth/index.html
@@ -9,17 +9,23 @@
       href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
       rel="stylesheet"
     />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
     <style>
       body {
         display: flex;
         align-items: center;
         justify-content: center;
         height: 100vh;
-        background: #f8f9fa;
+        background: var(--main-bg);
+        color: var(--main-text);
       }
       .login-box {
         padding: 2rem;
-        background: white;
+        background: var(--navbar-bg);
+        color: var(--main-text);
         border-radius: 0.5rem;
         box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
         width: 100%;
@@ -28,6 +34,12 @@
     </style>
   </head>
   <body>
+    <button
+      class="btn btn-outline-dark position-absolute top-0 end-0 m-3"
+      id="themeToggle"
+    >
+      <i class="bi bi-moon"></i>
+    </button>
     <div class="login-box">
       <h4 class="mb-4 text-center">Admin Login</h4>
       <form id="loginForm">
@@ -44,6 +56,7 @@
       </form>
     </div>
     <script src="../../config.js"></script>
+    <script src="../../theme.js"></script>
     <script>
       if (
         !sessionStorage.getItem("jwt_token") &&

--- a/admin/index.html
+++ b/admin/index.html
@@ -10,6 +10,10 @@
       rel="stylesheet"
       crossorigin="anonymous"
     />
+    <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
     <style>
       body {
         padding-top: 5rem;
@@ -27,7 +31,7 @@
     </style>
   </head>
   <body>
-    <nav class="navbar navbar-expand-lg bg-white fixed-top">
+    <nav class="navbar navbar-expand-lg bg-body fixed-top">
       <div class="container-fluid">
         <img src="../QKSS-logo.jpg.png" alt="QKSS-logo" height="40" />
         <div class="d-flex ms-auto align-items-center gap-2">
@@ -41,6 +45,9 @@
           </select>
           <button class="btn btn-outline-dark btn-sm" onclick="logout()">
             Logout
+          </button>
+          <button class="btn btn-outline-dark btn-sm" id="themeToggle">
+            <i class="bi bi-moon"></i>
           </button>
         </div>
       </div>
@@ -73,6 +80,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="../config.js"></script>
+    <script src="../theme.js"></script>
 
     <script>
       const PINS_API_URL = `${API_BASE_URL}/pins`;

--- a/admin/newpin/index.html
+++ b/admin/newpin/index.html
@@ -10,6 +10,10 @@
       crossorigin="anonymous"
     />
     <link
+      href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css"
+      rel="stylesheet"
+    />
+    <link
       rel="stylesheet"
       href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
       crossorigin=""
@@ -22,7 +26,7 @@
     </style>
   </head>
   <body>
-    <nav class="navbar sticky-top navbar-expand-lg bg-white mb-4">
+    <nav class="navbar sticky-top navbar-expand-lg bg-body mb-4">
       <div class="container-fluid">
         <img src="../../QKSS-logo.jpg.png" alt="QKSS-logo" height="40" />
         <div class="d-flex align-items-center gap-2 ms-auto">
@@ -36,6 +40,9 @@
           </select>
           <button class="btn btn-sm btn-outline-dark" onclick="logout()">
             Logout
+          </button>
+          <button class="btn btn-sm btn-outline-dark" id="themeToggle">
+            <i class="bi bi-moon"></i>
           </button>
         </div>
       </div>
@@ -260,7 +267,7 @@
         </div>
       </form>
     </div>
-    <footer class="bg-dark text-light text-center py-2">
+    <footer class="text-center py-2">
       <small>© 2025 QKSS Map Viewer. Data sourced from our API.</small>
     </footer>
     <script
@@ -272,6 +279,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="../../config.js"></script>
+    <script src="../../theme.js"></script>
 
     <script>
       const PINS_API_URL = `${API_BASE_URL}/pins`;

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" href="vendor/flatpickr.monthSelect.css" />
   </head>
   <body class="d-flex flex-column vh-100">
-    <nav class="navbar navbar-expand-lg bg-white">
+    <nav class="navbar navbar-expand-lg bg-body">
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="/">
           <img src="KCSS-logo.png" alt="KCSS logo" height="40" class="me-2" />
@@ -83,6 +83,9 @@
             <a class="btn btn-outline-light me-2" href="about.html">About</a>
             <button class="btn btn-outline-light" id="toggleSidebar">
               <i class="bi bi-layout-sidebar"></i>
+            </button>
+            <button class="btn btn-outline-dark" id="themeToggle">
+              <i class="bi bi-moon"></i>
             </button>
           </div>
         </div>
@@ -297,7 +300,7 @@
       </div>
     </div>
 
-    <footer class="bg-white text-dark text-center py-0.5">
+    <footer class="text-center py-0.5">
       <small>
         This site is part of a project supported by NED (National Endowment for
         Democracy), titled &#39;Increasing Government Transparency and
@@ -317,6 +320,7 @@
     <script src="vendor/flatpickr.min.js"></script>
     <script src="vendor/flatpickr.monthSelect.js"></script>
     <script src="config.js"></script>
+    <script src="theme.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/news/index.html
+++ b/news/index.html
@@ -16,7 +16,7 @@
     <link rel="stylesheet" href="../style.css" />
   </head>
   <body class="d-flex flex-column min-vh-100">
-    <nav class="navbar navbar-expand-lg bg-white">
+    <nav class="navbar navbar-expand-lg bg-body">
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="/">
           <img
@@ -71,6 +71,9 @@
               </li>
             </ul>
           </div>
+          <button class="btn btn-outline-dark ms-2" id="themeToggle">
+            <i class="bi bi-moon"></i>
+          </button>
         </div>
       </div>
     </nav>
@@ -107,7 +110,7 @@
       </article>
     </main>
 
-    <footer class="bg-dark text-light text-center py-2 mt-auto">
+    <footer class="text-center py-2 mt-auto">
       <small
         >This site is part of a project supported by NED (National Endowment for
         Democracy), titled 'Increasing Government Transparency and
@@ -123,6 +126,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="../config.js"></script>
+    <script src="../theme.js"></script>
     <script>
       function getLang() {
         return localStorage.getItem("lang") || "en";

--- a/style.css
+++ b/style.css
@@ -1,6 +1,17 @@
 :root {
   --navbar-height: 56px; /* Bootstrap default */
   --search-height: 60px; /* adjust to your mobile search bar */
+  --main-bg: #ffffff;
+  --main-text: #000000;
+  --navbar-bg: #ffffff;
+  --navbar-link: #108edde6;
+}
+
+[data-bs-theme="dark"] {
+  --main-bg: #212529;
+  --main-text: #f8f9fa;
+  --navbar-bg: #343a40;
+  --navbar-link: #93cdff;
 }
 
 /* 1. Full-screen flex container */
@@ -13,21 +24,22 @@ body {
 body {
   display: flex;
   flex-direction: column;
-  color: #000;
+  color: var(--main-text);
+  background-color: var(--main-bg);
 }
 
 /* 2. Fixed-height navbar */
 .navbar {
   flex: 0 0 var(--navbar-height);
-  background-color: #fff !important;
+  background-color: var(--navbar-bg) !important;
 }
 
 .navbar a,
 .navbar button,
 .navbar span,
 .navbar .navbar-brand {
-  color: #108edde6 !important;
-  border-color: #108edde6 !important;
+  color: var(--navbar-link) !important;
+  border-color: var(--navbar-link) !important;
 }
 
 /* 3. Optional search bar (only if you have one above the map) */
@@ -101,4 +113,9 @@ body {
 /* News page */
 .news-card {
   max-width: 860px;
+}
+
+footer {
+  background-color: var(--navbar-bg) !important;
+  color: var(--main-text) !important;
 }

--- a/theme.js
+++ b/theme.js
@@ -1,0 +1,25 @@
+function setTheme(theme) {
+  document.documentElement.setAttribute('data-bs-theme', theme);
+  localStorage.setItem('theme', theme);
+  const btn = document.getElementById('themeToggle');
+  if (btn) {
+    if (theme === 'dark') {
+      btn.classList.remove('btn-outline-dark');
+      btn.classList.add('btn-outline-light');
+      btn.innerHTML = '<i class="bi bi-sun"></i>';
+    } else {
+      btn.classList.remove('btn-outline-light');
+      btn.classList.add('btn-outline-dark');
+      btn.innerHTML = '<i class="bi bi-moon"></i>';
+    }
+  }
+}
+function toggleTheme() {
+  const current = localStorage.getItem('theme') || 'light';
+  setTheme(current === 'dark' ? 'light' : 'dark');
+}
+document.addEventListener('DOMContentLoaded', () => {
+  setTheme(localStorage.getItem('theme') || 'light');
+  const btn = document.getElementById('themeToggle');
+  if (btn) btn.addEventListener('click', toggleTheme);
+});


### PR DESCRIPTION
## Summary
- implement theme.js for toggling Bootstrap `data-bs-theme`
- style nav and body with CSS variables to support dark theme
- add theme toggle buttons to all pages
- include Bootstrap icons where needed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_68571df29c908324a049337b894af0ee