### PR TITLE
Fix button colors for dark theme

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,8 +80,8 @@
                 </li>
               </ul>
             </div>
-            <a class="btn btn-outline-light me-2" href="about.html">About</a>
-            <button class="btn btn-outline-light" id="toggleSidebar">
+            <a class="btn btn-outline-dark me-2" href="about.html">About</a>
+            <button class="btn btn-outline-dark" id="toggleSidebar">
               <i class="bi bi-layout-sidebar"></i>
             </button>
             <button class="btn btn-outline-dark" id="themeToggle">

--- a/style.css
+++ b/style.css
@@ -119,3 +119,9 @@ footer {
   background-color: var(--navbar-bg) !important;
   color: var(--main-text) !important;
 }
+
+/* Ensure outline-dark buttons remain visible in dark mode */
+[data-bs-theme="dark"] .btn-outline-dark {
+  color: var(--main-text) !important;
+  border-color: var(--main-text) !important;
+}


### PR DESCRIPTION
## Summary
- ensure outline-dark buttons stay visible in dark mode
- fix About and Sidebar buttons so they're readable on the navbar

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68571ff0a3788324874e45eefcfd4016