### PR TITLE
Implement shared footer and site title with language support

### DIFF
--- a/about.html
+++ b/about.html
@@ -20,11 +20,30 @@
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="./">
           <img src="KCSS-logo.png" alt="KCSS logo" height="40" class="me-2" />
-          <span>KCSS Map</span>
+          <span id="siteTitle"></span>
         </a>
-        <button class="btn btn-outline-dark ms-auto" id="themeToggle">
-          <i class="bi bi-moon"></i>
-        </button>
+        <div class="d-flex ms-auto align-items-center gap-2">
+          <div class="nav-item dropdown">
+            <a
+              class="nav-link dropdown-toggle"
+              href="#"
+              id="langDropdown"
+              role="button"
+              data-bs-toggle="dropdown"
+              aria-expanded="false"
+            >
+              <i class="bi bi-translate"></i>
+            </a>
+            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="langDropdown">
+              <li><button class="dropdown-item lang-option" data-lang="en">English</button></li>
+              <li><button class="dropdown-item lang-option" data-lang="sq">Shqip</button></li>
+              <li><button class="dropdown-item lang-option" data-lang="sr">Srpski</button></li>
+            </ul>
+          </div>
+          <button class="btn btn-outline-dark" id="themeToggle">
+            <i class="bi bi-moon"></i>
+          </button>
+        </div>
       </div>
     </nav>
     <main class="flex-grow-1 container my-4">
@@ -58,7 +77,7 @@
       </p>
     </main>
     <footer class="text-center py-2">
-      <small>
+      <small id="footerText">
         This site is part of a project supported by NED (National Endowment for
         Democracy), titled &#39;Increasing Government Transparency and
         Accountability in Interethnic Dialogue,&#39; and implemented by KCSS.
@@ -72,5 +91,6 @@
       crossorigin="anonymous"
     ></script>
     <script src="theme.js"></script>
+    <script src="site.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -33,7 +33,7 @@
       <div class="container-fluid">
         <a class="navbar-brand d-flex align-items-center" href="/">
           <img src="KCSS-logo.png" alt="KCSS logo" height="40" class="me-2" />
-          <span class="text-center py-0.5 fs-4">Online Risk Monitore</span>
+          <span id="siteTitle" class="text-center py-0.5 fs-4"></span>
         </a>
         <button
           class="navbar-toggler"
@@ -301,7 +301,7 @@
     </div>
 
     <footer class="text-center py-0.5">
-      <small>
+      <small id="footerText">
         This site is part of a project supported by NED (National Endowment for
         Democracy), titled &#39;Increasing Government Transparency and
         Accountability in Interethnic Dialogue,&#39; and implemented by KCSS.
@@ -321,6 +321,7 @@
     <script src="vendor/flatpickr.monthSelect.js"></script>
     <script src="config.js"></script>
     <script src="theme.js"></script>
+    <script src="site.js"></script>
     <script src="app.js"></script>
   </body>
 </html>

--- a/news/index.html
+++ b/news/index.html
@@ -25,7 +25,7 @@
             height="40"
             class="me-2"
           />
-          <span>QKSS Map</span>
+          <span id="siteTitle"></span>
         </a>
         <button
           class="navbar-toggler"
@@ -111,7 +111,7 @@
     </main>
 
     <footer class="text-center py-2 mt-auto">
-      <small
+      <small id="footerText"
         >This site is part of a project supported by NED (National Endowment for
         Democracy), titled 'Increasing Government Transparency and
         Accountability in Interethnic Dialogue,' and implemented by KCSS. The
@@ -127,16 +127,13 @@
     ></script>
     <script src="../config.js"></script>
     <script src="../theme.js"></script>
+    <script src="../site.js"></script>
     <script>
-      function getLang() {
-        return localStorage.getItem("lang") || "en";
-      }
       function setLang(lang) {
-        localStorage.setItem("lang", lang);
+        SiteLang.set(lang);
         updateLangDropdownDisplay();
         loadNews();
       }
-      const LANG_LABELS = { en: "English", sq: "Shqip", sr: "Srpski" };
       const UI_STRINGS = {
         en: {
           externalLink: "Open Original Article",
@@ -164,7 +161,7 @@
         },
       };
       function updateLangDropdownDisplay() {
-        const current = getLang();
+        const current = SiteLang.get();
         const toggle = document.getElementById("langDropdown");
         toggle.innerHTML = `<i class="bi bi-translate"></i> ${LANG_LABELS[current]}`;
       }
@@ -181,7 +178,7 @@
           const res = await fetch(`${API_BASE_URL}/pins/${id}`);
           if (!res.ok) throw new Error("Failed to load news");
           const pin = await res.json();
-          const lang = getLang();
+          const lang = SiteLang.get();
           const city = pin.city || {};
           const title =
             (pin.title && pin.title[lang]) || pin.title?.en || pin.title || "";
@@ -198,7 +195,7 @@
           ).textContent = `${pin.lat}, ${pin.lng}`;
           document.getElementById("newsCategory").textContent =
             pin.city || "N/A";
-          const u = UI_STRINGS[getLang()];
+          const u = UI_STRINGS[SiteLang.get()];
           document.getElementById("externalLink").textContent = u.externalLink;
           document.getElementById("externalLink").href = pin.articleUrl || "#";
           document.querySelector("a.btn-secondary").textContent = u.back;
@@ -215,7 +212,7 @@
       window.addEventListener("DOMContentLoaded", loadNews);
 
       function copyNewsLink() {
-        const u = UI_STRINGS[getLang()];
+        const u = UI_STRINGS[SiteLang.get()];
         navigator.clipboard.writeText(window.location.href).then(() => {
           const btn = document.activeElement;
           if (btn && btn.tagName === "BUTTON") {

--- a/site.js
+++ b/site.js
@@ -1,0 +1,44 @@
+const LANG_LABELS = { en: "English", sq: "Shqip", sr: "Srpski" };
+const SITE_STRINGS = {
+  en: {
+    title: "QKSS Map",
+    footer:
+      "This site is part of a project supported by NED (National Endowment for Democracy), titled 'Increasing Government Transparency and Accountability in Interethnic Dialogue,' and implemented by KCSS. The authors wrote the specific chapters within their own capacities. As such, the views presented in this site do not necessarily reflect the views of KCSS or NED.",
+  },
+  sq: {
+    title: "Harta e QKSS",
+    footer:
+      "Kjo faqe është pjesë e një projekti të mbështetur nga NED (National Endowment for Democracy), të titulluar 'Rritja e Transparencës së Qeverisë dhe Llogaridhënies në Dialogun Ndëretnik', dhe zbatohet nga KCSS. Autorët kanë shkruar kapitujt përkatës në kapacitetet e tyre personale. Prandaj, pikëpamjet e shprehura në këtë faqe nuk pasqyrojnë domosdoshmërisht pikëpamjet e KCSS ose NED.",
+  },
+  sr: {
+    title: "KCSS Mapa",
+    footer:
+      "Ovaj sajt je deo projekta koji podržava NED (National Endowment for Democracy) pod nazivom 'Povećanje transparentnosti vlade i odgovornosti u međuetničkom dijalogu', a sprovodi ga KCSS. Autori su pisali pojedina poglavlja u ličnom kapacitetu, pa stavovi izneti na ovom sajtu ne odražavaju nužno stavove KCSS-a ili NED-a.",
+  },
+};
+const SiteLang = {
+  get() {
+    return localStorage.getItem("lang") || "en";
+  },
+  set(lang) {
+    localStorage.setItem("lang", lang);
+    SiteLang.apply();
+  },
+  apply() {
+    const lang = SiteLang.get();
+    const brand = document.getElementById("siteTitle");
+    if (brand) brand.textContent = SITE_STRINGS[lang].title;
+    const footer = document.getElementById("footerText");
+    if (footer) footer.textContent = SITE_STRINGS[lang].footer;
+    const toggle = document.getElementById("langDropdown");
+    if (toggle)
+      toggle.innerHTML = `<i class="bi bi-translate"></i> ${LANG_LABELS[lang]}`;
+  },
+};
+document.addEventListener("DOMContentLoaded", () => {
+  document.querySelectorAll(".lang-option").forEach((btn) => {
+    btn.addEventListener("click", () => SiteLang.set(btn.dataset.lang));
+  });
+  SiteLang.apply();
+});
+window.SiteLang = SiteLang;


### PR DESCRIPTION
## Summary
- add `site.js` for basic language handling
- update all pages to use one site title and footer
- enable language switching on the about and news pages

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6857350f20dc8324bf02bd73b758a718