### PR TITLE
Unify language helpers

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -111,6 +111,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="../theme.js"></script>
+    <script src="../lang.js"></script>
     <script src="../site.js"></script>
   </body>
 </html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -84,22 +84,20 @@
       crossorigin="anonymous"
     ></script>
     <script src="../config.js"></script>
+    <script src="../lang.js"></script>
     <script src="../theme.js"></script>
 
     <script>
       const PINS_API_URL = `${API_BASE_URL}/pins`;
 
-      function getLang() {
-        return localStorage.getItem("lang") || "en";
-      }
 
       document.getElementById("languageSwitcher").value = getLang();
       document
         .getElementById("languageSwitcher")
-        .addEventListener("change", (e) => {
-          localStorage.setItem("lang", e.target.value);
-          location.reload();
-        });
+          .addEventListener("change", (e) => {
+            setLang(e.target.value);
+            location.reload();
+          });
 
       function showAlert(type, msg) {
         const container = document.getElementById("alertContainer");

--- a/admin/newpin/index.html
+++ b/admin/newpin/index.html
@@ -279,6 +279,7 @@
       crossorigin="anonymous"
     ></script>
     <script src="../../config.js"></script>
+    <script src="../../lang.js"></script>
     <script src="../../theme.js"></script>
 
     <script>
@@ -352,14 +353,11 @@
         });
       });
 
-      function getLang() {
-        return localStorage.getItem("lang") || "en";
-      }
       document.getElementById("languageSwitcher").value = getLang();
       document
         .getElementById("languageSwitcher")
         .addEventListener("change", (e) => {
-          localStorage.setItem("lang", e.target.value);
+          setLang(e.target.value);
           location.reload();
         });
 

--- a/app.js
+++ b/app.js
@@ -1,8 +1,3 @@
-const LANG_LABELS = {
-  en: "English",
-  sq: "Shqip",
-  sr: "Srpski",
-};
 const UI_STRINGS = {
   en: {
     locations: "Locations",
@@ -136,22 +131,6 @@ let map;
 let markers = [];
 let allPins = [];
 
-function getLang() {
-  return localStorage.getItem("lang") || "en";
-}
-
-function setLang(lang) {
-  localStorage.setItem("lang", lang);
-  updateLangDropdownDisplay();
-  updateUIStrings();
-  addMarkers(allPins);
-  populateList(allPins);
-}
-function updateLangDropdownDisplay() {
-  const current = getLang();
-  const toggle = document.getElementById("langDropdown");
-  toggle.innerHTML = `<i class="bi bi-translate"></i> ${LANG_LABELS[current]}`;
-}
 
 function normalizePinTitle(pin) {
   if (typeof pin.title === "string") {

--- a/index.html
+++ b/index.html
@@ -320,6 +320,7 @@
     <script src="vendor/flatpickr.min.js"></script>
     <script src="vendor/flatpickr.monthSelect.js"></script>
     <script src="config.js"></script>
+    <script src="lang.js"></script>
     <script src="theme.js"></script>
     <script src="site.js"></script>
     <script src="app.js"></script>

--- a/lang.js
+++ b/lang.js
@@ -1,120 +1,10 @@
-UI_STRINGS = {
-  en: {
-    locations: "Locations",
-    searchPlaceholder: "Filter by title...",
-    searchNavPlaceholder: "Search pins...",
-    close: "Close",
-    pinDetailsTitle: "Pin Details",
-    coordsLabel: "Coordinates:",
-    categoryLabel: "Category:",
-    navBrand: "Pin Admin",
-    navLogout: "Logout",
-    formHeading: "Create New Pin",
-    formSubheading: "Click on the map to choose latitude/longitude.",
-    labelTitleEn: "Title (English)",
-    labelTitleSq: "Titulli (Shqip)",
-    labelTitleSr: "Наслов (Srpski)",
-    labelDescEn: "Description (English)",
-    labelDescSq: "Përshkrimi (Shqip)",
-    labelDescSr: "Опис (Srpski)",
-    labelCity: "City (optional)",
-    labelLat: "Latitude",
-    labelLng: "Longitude",
-    labelUrl: "Article URL",
-    btnSubmit: "Submit",
-    btnBack: "⬅ Back",
-
-    adminTitle: "Manage Map Pins",
-    btnCreateNewPin: "Create New Pin",
-    tableHeaderTitle: "Title",
-    tableHeaderLat: "Lat",
-    tableHeaderLng: "Lng",
-    tableHeaderUrl: "URL",
-    tableHeaderActions: "Actions",
-    alertDeleteSuccess: "Pin deleted.",
-    alertDeleteUnauthorized: "Unauthorized. Please log in again.",
-    alertDeleteForbidden:
-      "Forbidden. You do not have permission to delete this pin.",
-    alertDeleteFail: "Failed to delete pin (status {status}).",
-    alertFetchFail: "Failed to fetch pins.",
-  },
-  sq: {
-    locations: "Vendndodhjet",
-    searchPlaceholder: "Filtro sipas titullit…",
-    searchNavPlaceholder: "Kërko pika…",
-    close: "Mbylle",
-    pinDetailsTitle: "Detajet e Pikës",
-    coordsLabel: "Koordinatat:",
-    categoryLabel: "Kategoria:",
-    navBrand: "Admin Pikash",
-    navLogout: "Dil",
-    formHeading: "Krijo Pikë të Re",
-    formSubheading: "Klikoni në hartë për të zgjedhur koordinatat.",
-    labelTitleEn: "Titulli (Anglisht)",
-    labelTitleSq: "Titulli (Shqip)",
-    labelTitleSr: "Titulli (Srpski)",
-    labelDescEn: "Përshkrimi (Anglisht)",
-    labelDescSq: "Përshkrimi (Shqip)",
-    labelDescSr: "Përshkrimi (Srpski)",
-    labelCity: "Qyteti (opsional)",
-    labelLat: "Gjerësia",
-    labelLng: "Gjatësia",
-    labelUrl: "URL Artikulli",
-    btnSubmit: "Dërgo",
-    btnBack: "⬅ Kthehu",
-
-    adminTitle: "Menaxho Pikët e Hartës",
-    btnCreateNewPin: "Krijo Pikë të Re",
-    tableHeaderTitle: "Titulli",
-    tableHeaderLat: "Gjerësia",
-    tableHeaderLng: "Gjatësia",
-    tableHeaderUrl: "URL",
-    tableHeaderActions: "Veprimet",
-    alertDeleteSuccess: "Pika u fshi.",
-    alertDeleteUnauthorized:
-      "Jo i autorizuar. Ju lutemi identifikohuni përsëri.",
-    alertDeleteForbidden: "Nuk keni leje për këtë veprim.",
-    alertDeleteFail: "Dështoi fshirja e pikës (status {status}).",
-    alertFetchFail: "Dështoi marrja e pikave.",
-  },
-  sr: {
-    locations: "Lokacije",
-    searchPlaceholder: "Filtriraj po nazivu…",
-    searchNavPlaceholder: "Pretraži pinove…",
-    close: "Zatvori",
-    pinDetailsTitle: "Detalji Pin-a",
-    coordsLabel: "Koordinate:",
-    categoryLabel: "Kategorija:",
-    navBrand: "Admin Pinova",
-    navLogout: "Odjavi se",
-    formHeading: "Kreiraj Novi Pin",
-    formSubheading: "Kliknite na mapu za izbor koordinata.",
-    labelTitleEn: "Naslov (Engleski)",
-    labelTitleSq: "Naslov (Šqip)",
-    labelTitleSr: "Naslov (Srpski)",
-    labelDescEn: "Opis (Engleski)",
-    labelDescSq: "Opis (Šqip)",
-    labelDescSr: "Opis (Srpski)",
-    labelCity: "Grad (opciono)",
-    labelLat: "Geografska širina",
-    labelLng: "Geografska dužina",
-    labelUrl: "URL Članka",
-    btnSubmit: "Sačuvaj",
-    btnBack: "⬅ Nazad",
-
-    adminTitle: "Upravljanje Pinovima",
-    btnCreateNewPin: "Kreiraj Novi Pin",
-    tableHeaderTitle: "Naslov",
-    tableHeaderLat: "Lat",
-    tableHeaderLng: "Lng",
-    tableHeaderUrl: "URL",
-    tableHeaderActions: "Akcije",
-    alertDeleteSuccess: "Pin je obrisan.",
-    alertDeleteUnauthorized: "Niste autorizovani. Molimo ponovo se prijavite.",
-    alertDeleteForbidden: "Nemate dozvolu za ovu akciju.",
-    alertDeleteFail: "Brisanje pina nije uspelo (status {status}).",
-    alertFetchFail: "Neuspešno preuzimanje pinova.",
-  },
+/**
+ * Shared language utilities used across the QKSS site.
+ */
+const LANG_LABELS = {
+  en: "English",
+  sq: "Shqip",
+  sr: "Srpski",
 };
 
 function getLang() {
@@ -124,40 +14,22 @@ function getLang() {
 function setLang(lang) {
   localStorage.setItem("lang", lang);
   updateLangDropdownDisplay();
-  updateLanguageUI();
-  updateUIStrings();
+  if (window.SiteLang && typeof window.SiteLang.apply === "function") {
+    window.SiteLang.apply();
+  }
+  if (typeof updateLanguageUI === "function") updateLanguageUI();
+  if (typeof updateUIStrings === "function") updateUIStrings();
 }
 
 function updateLangDropdownDisplay() {
-  const lbl = document.querySelector("#languageSwitcher");
-  const current = getLang();
-  if (lbl) lbl.value = current;
-}
-
-function updateLanguageUI() {
-  const s = UI_STRINGS[getLang()];
-  document.querySelector(".navbar-brand").textContent = "🗺 " + s.navBrand;
-  document.querySelector('button[onclick="logout()"]').textContent =
-    s.navLogout;
-  const title = document.querySelector("h2");
-  if (title) title.textContent = s.adminTitle;
-  const createBtn = document.querySelector("a.btn-dark");
-  if (createBtn) createBtn.textContent = s.btnCreateNewPin;
-  const ths = document.querySelectorAll("table thead th");
-  if (ths.length >= 5) {
-    ths[0].textContent = s.tableHeaderTitle;
-    ths[1].textContent = s.tableHeaderLat;
-    ths[2].textContent = s.tableHeaderLng;
-    ths[3].textContent = s.tableHeaderUrl;
-    ths[4].textContent = s.tableHeaderActions;
+  const toggle = document.getElementById("langDropdown");
+  if (toggle) {
+    toggle.innerHTML = `<i class="bi bi-translate"></i> ${LANG_LABELS[getLang()]}`;
   }
 }
 
-function updateUIStrings() {
-  const u = UI_STRINGS[getLang()];
-}
+// expose helpers globally
+window.LANG_LABELS = LANG_LABELS;
 window.getLang = getLang;
 window.setLang = setLang;
 window.updateLangDropdownDisplay = updateLangDropdownDisplay;
-window.updateLanguageUI = updateLanguageUI;
-window.updateUIStrings = updateUIStrings;

--- a/news/index.html
+++ b/news/index.html
@@ -56,17 +56,17 @@
             >
               <li>
                 <button class="dropdown-item lang-option" data-lang="en">
-                  English
+        btn.addEventListener("click", () => { setLang(btn.dataset.lang); loadNews(); });
                 </button>
               </li>
               <li>
                 <button class="dropdown-item lang-option" data-lang="sq">
-                  Shqip
+        btn.addEventListener("click", () => { setLang(btn.dataset.lang); loadNews(); });
                 </button>
               </li>
               <li>
                 <button class="dropdown-item lang-option" data-lang="sr">
-                  Srpski
+        btn.addEventListener("click", () => { setLang(btn.dataset.lang); loadNews(); });
                 </button>
               </li>
             </ul>
@@ -126,16 +126,12 @@
       crossorigin="anonymous"
     ></script>
     <script src="../config.js"></script>
+    <script src="../lang.js"></script>
     <script src="../theme.js"></script>
     <script src="../app.js"></script>
     <script src="../site.js"></script>
 
     <script>
-      function setLang(lang) {
-        SiteLang.set(lang);
-        updateLangDropdownDisplay();
-        loadNews();
-      }
       const UI_STRINGS = {
         en: {
           externalLink: "Open Original Article",
@@ -162,13 +158,8 @@
           copied: "Kopirano!",
         },
       };
-      function updateLangDropdownDisplay() {
-        const current = SiteLang.get();
-        const toggle = document.getElementById("langDropdown");
-        toggle.innerHTML = `<i class="bi bi-translate"></i> ${LANG_LABELS[current]}`;
-      }
       document.querySelectorAll(".lang-option").forEach((btn) => {
-        btn.addEventListener("click", () => setLang(btn.dataset.lang));
+        btn.addEventListener("click", () => { setLang(btn.dataset.lang); loadNews(); });
       });
       updateLangDropdownDisplay();
 


### PR DESCRIPTION
## Summary
- centralize language functions in `lang.js`
- remove duplicated helpers from `app.js` and pages
- load `lang.js` across all pages

## Testing
- `node --check lang.js`
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6857c7beee988324826540e7d9eb541e