### PR TITLE
Unify navbar and sync language across pages

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -16,56 +16,6 @@
     />
   </head>
   <body class="d-flex flex-column vh-100">
-    <nav class="navbar navbar-expand-lg bg-body">
-      <div class="container-fluid">
-        <a class="navbar-brand d-flex align-items-center" href="./">
-          <img
-            src="../KCSS-logo.png"
-            alt="KCSS logo"
-            height="40"
-            class="me-2"
-          />
-          <span id="siteTitle"></span>
-        </a>
-        <div class="d-flex ms-auto align-items-center gap-2">
-          <div class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="langDropdown"
-              role="button"
-              data-bs-toggle="dropdown"
-              aria-expanded="false"
-            >
-              <i class="bi bi-translate"></i>
-            </a>
-            <ul
-              class="dropdown-menu dropdown-menu-end"
-              aria-labelledby="langDropdown"
-            >
-              <li>
-                <button class="dropdown-item lang-option" data-lang="en">
-                  English
-                </button>
-              </li>
-              <li>
-                <button class="dropdown-item lang-option" data-lang="sq">
-                  Shqip
-                </button>
-              </li>
-              <li>
-                <button class="dropdown-item lang-option" data-lang="sr">
-                  Srpski
-                </button>
-              </li>
-            </ul>
-          </div>
-          <button class="btn btn-outline-dark" id="themeToggle">
-            <i class="bi bi-moon"></i>
-          </button>
-        </div>
-      </div>
-    </nav>
     <main class="flex-grow-1 container my-4">
       <h1>About This Platform</h1>
       <p>
@@ -110,8 +60,9 @@
       src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"
       crossorigin="anonymous"
     ></script>
-    <script src="../theme.js"></script>
     <script src="../lang.js"></script>
+    <script src="../nav.js"></script>
+    <script src="../theme.js"></script>
     <script src="../site.js"></script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -29,68 +29,6 @@
     <link rel="stylesheet" href="vendor/flatpickr.monthSelect.css" />
   </head>
   <body class="d-flex flex-column vh-100">
-    <nav class="navbar navbar-expand-lg bg-body">
-      <div class="container-fluid">
-        <a class="navbar-brand d-flex align-items-center" href="/">
-          <img src="KCSS-logo.png" alt="KCSS logo" height="40" class="me-2" />
-          <span id="siteTitle" class="text-center py-0.5 fs-4"></span>
-        </a>
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#navMenu"
-          aria-controls="navMenu"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse justify-content-end" id="navMenu">
-          <div class="d-flex align-items-center gap-2">
-            <div class="nav-item dropdown">
-              <a
-                class="nav-link dropdown-toggle"
-                href="#"
-                id="langDropdown"
-                role="button"
-                data-bs-toggle="dropdown"
-                aria-expanded="false"
-              >
-                <i class="bi bi-translate"></i>
-              </a>
-              <ul
-                class="dropdown-menu dropdown-menu-end"
-                aria-labelledby="langDropdown"
-              >
-                <li>
-                  <button class="dropdown-item lang-option" data-lang="en">
-                    English
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-item lang-option" data-lang="sq">
-                    Shqip
-                  </button>
-                </li>
-                <li>
-                  <button class="dropdown-item lang-option" data-lang="sr">
-                    Srpski
-                  </button>
-                </li>
-              </ul>
-            </div>
-            <a class="btn btn-outline-dark me-2" href="/about/">About</a>
-            <button class="btn btn-outline-dark" id="toggleSidebar">
-              <i class="bi bi-layout-sidebar"></i>
-            </button>
-            <button class="btn btn-outline-dark" id="themeToggle">
-              <i class="bi bi-moon"></i>
-            </button>
-          </div>
-        </div>
-      </div>
-    </nav>
 
     <div class="flex-grow-1 d-flex overflow-hidden">
       <aside
@@ -321,6 +259,7 @@
     <script src="vendor/flatpickr.monthSelect.js"></script>
     <script src="config.js"></script>
     <script src="lang.js"></script>
+    <script src="nav.js"></script>
     <script src="theme.js"></script>
     <script src="site.js"></script>
     <script src="app.js"></script>

--- a/lang.js
+++ b/lang.js
@@ -33,3 +33,13 @@ window.LANG_LABELS = LANG_LABELS;
 window.getLang = getLang;
 window.setLang = setLang;
 window.updateLangDropdownDisplay = updateLangDropdownDisplay;
+window.addEventListener("storage", (e) => {
+  if (e.key === "lang") {
+    updateLangDropdownDisplay();
+    if (window.SiteLang && typeof window.SiteLang.apply === "function") {
+      window.SiteLang.apply();
+    }
+    if (typeof updateLanguageUI === "function") updateLanguageUI();
+    if (typeof updateUIStrings === "function") updateUIStrings();
+  }
+});

--- a/nav.js
+++ b/nav.js
@@ -1,0 +1,44 @@
+(function(){
+  const NAV_HTML = `\
+<nav class="navbar navbar-expand-lg bg-body">
+  <div class="container-fluid">
+    <a class="navbar-brand d-flex align-items-center" href="/">
+      <img src="/KCSS-logo.png" alt="KCSS logo" height="40" class="me-2" />
+      <span id="siteTitle" class="text-center py-0.5 fs-4"></span>
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navMenu" aria-controls="navMenu" aria-expanded="false" aria-label="Toggle navigation">
+      <span class="navbar-toggler-icon"></span>
+    </button>
+    <div class="collapse navbar-collapse justify-content-end" id="navMenu">
+      <div class="d-flex align-items-center gap-2">
+        <div class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="langDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+            <i class="bi bi-translate"></i>
+          </a>
+          <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="langDropdown">
+            <li><button class="dropdown-item lang-option" data-lang="en">English</button></li>
+            <li><button class="dropdown-item lang-option" data-lang="sq">Shqip</button></li>
+            <li><button class="dropdown-item lang-option" data-lang="sr">Srpski</button></li>
+          </ul>
+        </div>
+        <a class="btn btn-outline-dark me-2" href="/about/">About</a>
+        <button class="btn btn-outline-dark" id="toggleSidebar">
+          <i class="bi bi-layout-sidebar"></i>
+        </button>
+        <button class="btn btn-outline-dark" id="themeToggle">
+          <i class="bi bi-moon"></i>
+        </button>
+      </div>
+    </div>
+  </div>
+</nav>`;
+
+  function insertNav(){
+    const temp = document.createElement('div');
+    temp.innerHTML = NAV_HTML.trim();
+    const nav = temp.firstElementChild;
+    document.body.prepend(nav);
+  }
+
+  document.addEventListener('DOMContentLoaded', insertNav);
+})();

--- a/news/index.html
+++ b/news/index.html
@@ -16,67 +16,6 @@
     <link rel="stylesheet" href="../style.css" />
   </head>
   <body class="d-flex flex-column min-vh-100">
-    <nav class="navbar navbar-expand-lg bg-body">
-      <div class="container-fluid">
-        <a class="navbar-brand d-flex align-items-center" href="/">
-          <img
-            src="../QKSS-logo.jpg.png"
-            alt="QKSS-logo"
-            height="40"
-            class="me-2"
-          />
-          <span id="siteTitle"></span>
-        </a>
-        <button
-          class="navbar-toggler"
-          type="button"
-          data-bs-toggle="collapse"
-          data-bs-target="#navMenu"
-          aria-controls="navMenu"
-          aria-expanded="false"
-          aria-label="Toggle navigation"
-        >
-          <span class="navbar-toggler-icon"></span>
-        </button>
-        <div class="collapse navbar-collapse justify-content-end" id="navMenu">
-          <div class="nav-item dropdown">
-            <a
-              class="nav-link dropdown-toggle"
-              href="#"
-              id="langDropdown"
-              role="button"
-              data-bs-toggle="dropdown"
-              aria-expanded="false"
-            >
-              <i class="bi bi-translate"></i>
-            </a>
-            <ul
-              class="dropdown-menu dropdown-menu-end"
-              aria-labelledby="langDropdown"
-            >
-              <li>
-                <button class="dropdown-item lang-option" data-lang="en">
-                  English
-                </button>
-              </li>
-              <li>
-                <button class="dropdown-item lang-option" data-lang="sq">
-                  Shqip
-                </button>
-              </li>
-              <li>
-                <button class="dropdown-item lang-option" data-lang="sr">
-                  Srpski
-                </button>
-              </li>
-            </ul>
-          </div>
-          <button class="btn btn-outline-dark ms-2" id="themeToggle">
-            <i class="bi bi-moon"></i>
-          </button>
-        </div>
-      </div>
-    </nav>
 
     <main class="flex-grow-1 container py-5" id="content">
       <article class="news-card card shadow-lg border-0 mx-auto">
@@ -127,9 +66,10 @@
     ></script>
     <script src="../config.js"></script>
     <script src="../lang.js"></script>
+    <script src="../nav.js"></script>
     <script src="../theme.js"></script>
-    <script src="../app.js"></script>
     <script src="../site.js"></script>
+    <script src="../app.js"></script>
 
     <script>
       document.querySelectorAll(".lang-option").forEach((btn) => {


### PR DESCRIPTION
## Summary
- inject a shared navbar from `nav.js`
- add cross-tab language updates
- load shared navbar on index, about and news pages

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_685811583e98832480cdde3dc1a18e4b