### PR TITLE
Fix pin refresh after language change

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -94,10 +94,14 @@
       document.getElementById("languageSwitcher").value = getLang();
       document
         .getElementById("languageSwitcher")
-          .addEventListener("change", (e) => {
-            setLang(e.target.value);
-            location.reload();
-          });
+        .addEventListener("change", (e) => {
+          setLang(e.target.value);
+        });
+
+      function refreshPinsLanguage() {
+        fetchPins();
+      }
+      window.refreshPinsLanguage = refreshPinsLanguage;
 
       function showAlert(type, msg) {
         const container = document.getElementById("alertContainer");

--- a/admin/newpin/index.html
+++ b/admin/newpin/index.html
@@ -358,8 +358,12 @@
         .getElementById("languageSwitcher")
         .addEventListener("change", (e) => {
           setLang(e.target.value);
-          location.reload();
         });
+
+      function refreshPinsLanguage() {
+        location.reload();
+      }
+      window.refreshPinsLanguage = refreshPinsLanguage;
 
       document
         .getElementById("createPinForm")

--- a/news/index.html
+++ b/news/index.html
@@ -75,10 +75,14 @@
       document.querySelectorAll(".lang-option").forEach((btn) => {
         btn.addEventListener("click", () => {
           setLang(btn.dataset.lang);
-          loadNews();
         });
       });
       updateLangDropdownDisplay();
+
+      function refreshPinsLanguage() {
+        loadNews();
+      }
+      window.refreshPinsLanguage = refreshPinsLanguage;
 
       async function loadNews() {
         const params = new URLSearchParams(window.location.search);


### PR DESCRIPTION
## Summary
- ensure admin dashboard refreshes pins when language changes
- ensure pin creation page reloads on language change
- update news details page to reload the pin on language change

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68583b50bf688324824e87943e6e527f