### PR TITLE
Fix language switch updates in news

### DIFF
--- a/site.js
+++ b/site.js
@@ -36,7 +36,13 @@ const SiteLang = {
 };
 document.addEventListener("DOMContentLoaded", () => {
   document.querySelectorAll(".lang-option").forEach((btn) => {
-    btn.addEventListener("click", () => SiteLang.set(btn.dataset.lang));
+    btn.addEventListener("click", () => {
+      if (typeof window.setLang === "function") {
+        window.setLang(btn.dataset.lang);
+      } else {
+        SiteLang.set(btn.dataset.lang);
+      }
+    });
   });
   SiteLang.apply();
 });


### PR DESCRIPTION
## Summary
- update language dropdown listener to invoke global setLang if defined so news content refreshes

## Testing
- `node -e "require('./site.js')"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68583ea9642c83249571cb10feaeff3f